### PR TITLE
Fix "Call to undefined function" errors

### DIFF
--- a/samples/consolesample/composer.json
+++ b/samples/consolesample/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "configcat/configcat-client-php7": "^1",
+        "configcat/configcat-client-php7": "^3",
         "monolog/monolog": "^1.0"
     }
 }

--- a/src/ConfigCatClient.php
+++ b/src/ConfigCatClient.php
@@ -18,7 +18,6 @@ use ConfigCat\Log\InternalLogger;
 use ConfigCat\Log\LogLevel;
 use ConfigCat\Override\FlagOverrides;
 use ConfigCat\Override\OverrideBehaviour;
-use Exception;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use stdClass;
@@ -669,7 +668,7 @@ final class ConfigCatClient implements ClientInterface
     private static function isValidSdkKey(string $sdkKey, bool $customBaseUrl): bool
     {
         $proxyPrefix = 'configcat-proxy/';
-        if ($customBaseUrl && strlen($sdkKey) > strlen($proxyPrefix) && str_starts_with($sdkKey, $proxyPrefix)) {
+        if ($customBaseUrl && strlen($sdkKey) > strlen($proxyPrefix) && Utils::str_starts_with($sdkKey, $proxyPrefix)) {
             return true;
         }
 

--- a/src/ConfigCatClient.php
+++ b/src/ConfigCatClient.php
@@ -28,7 +28,7 @@ use Throwable;
  */
 final class ConfigCatClient implements ClientInterface
 {
-    public const SDK_VERSION = '3.0.1';
+    public const SDK_VERSION = '3.0.2';
     private const CONFIG_JSON_CACHE_VERSION = 'v2';
 
     /** @var InternalLogger */

--- a/src/ConfigJson/ConditionContainer.php
+++ b/src/ConfigJson/ConditionContainer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ConfigCat\ConfigJson;
 
+use ConfigCat\Utils;
 use UnexpectedValueException;
 
 /**
@@ -30,7 +31,7 @@ final class ConditionContainer
      */
     public static function ensureList($conditions): array
     {
-        if (!is_array($conditions) || !array_is_list($conditions)) {
+        if (!is_array($conditions) || !Utils::array_is_list($conditions)) {
             throw new UnexpectedValueException('Condition list is invalid.');
         }
 

--- a/src/ConfigJson/PercentageOption.php
+++ b/src/ConfigJson/PercentageOption.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ConfigCat\ConfigJson;
 
+use ConfigCat\Utils;
 use UnexpectedValueException;
 
 /**
@@ -28,7 +29,7 @@ final class PercentageOption extends SettingValueContainer
      */
     public static function ensureList($percentageOptions): array
     {
-        if (!is_array($percentageOptions) || !array_is_list($percentageOptions)) {
+        if (!is_array($percentageOptions) || !Utils::array_is_list($percentageOptions)) {
             throw new UnexpectedValueException('Percentage option list is invalid.');
         }
 

--- a/src/ConfigJson/Segment.php
+++ b/src/ConfigJson/Segment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ConfigCat\ConfigJson;
 
+use ConfigCat\Utils;
 use UnexpectedValueException;
 
 /**
@@ -29,7 +30,7 @@ final class Segment
      */
     public static function ensureList($segments): array
     {
-        if (!is_array($segments) || !array_is_list($segments)) {
+        if (!is_array($segments) || !Utils::array_is_list($segments)) {
             throw new UnexpectedValueException('Segment list is invalid.');
         }
 

--- a/src/ConfigJson/TargetingRule.php
+++ b/src/ConfigJson/TargetingRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ConfigCat\ConfigJson;
 
+use ConfigCat\Utils;
 use UnexpectedValueException;
 
 /**
@@ -30,7 +31,7 @@ final class TargetingRule
      */
     public static function ensureList($targetingRules): array
     {
-        if (!is_array($targetingRules) || !array_is_list($targetingRules)) {
+        if (!is_array($targetingRules) || !Utils::array_is_list($targetingRules)) {
             throw new UnexpectedValueException('Targeting rule list is invalid.');
         }
 
@@ -71,7 +72,7 @@ final class TargetingRule
             if (!isset($percentageOptions) && is_array($simpleValue)) {
                 return false;
             }
-        } elseif (is_array($percentageOptions) && array_is_list($percentageOptions) && count($percentageOptions) > 0) {
+        } elseif (is_array($percentageOptions) && Utils::array_is_list($percentageOptions) && count($percentageOptions) > 0) {
             return true;
         }
 

--- a/src/RolloutEvaluator.php
+++ b/src/RolloutEvaluator.php
@@ -761,7 +761,7 @@ final class RolloutEvaluator
         foreach ($comparisonValues as $comparisonValue) {
             $item = self::ensureStringComparisonValue($comparisonValue);
 
-            $success = $startsWith ? str_starts_with($text, $item) : str_ends_with($text, $item);
+            $success = $startsWith ? Utils::str_starts_with($text, $item) : Utils::str_ends_with($text, $item);
 
             if ($success) {
                 return !$negate;
@@ -1164,7 +1164,7 @@ final class RolloutEvaluator
      */
     private static function ensureComparisonValues($comparisonValues): array
     {
-        if (!array_is_list($comparisonValues)) {
+        if (!Utils::array_is_list($comparisonValues)) {
             throw new UnexpectedValueException('Comparison value is missing or invalid.');
         }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -24,6 +24,60 @@ final class Utils
     }
 
     /**
+     * Polyfill for the `str_starts_with` function introduced in PHP 8.0.
+     */
+    public static function str_starts_with(string $haystack, string $needle): bool
+    {
+        // Source: https://github.com/symfony/polyfill/blob/v1.29.0/src/Php80/Php80.php#L96
+
+        return 0 === strncmp($haystack, $needle, \strlen($needle));
+    }
+
+    /**
+     * Polyfill for the `str_ends_with` function introduced in PHP 8.0.
+     */
+    public static function str_ends_with(string $haystack, string $needle): bool
+    {
+        // Source: https://github.com/symfony/polyfill/blob/v1.29.0/src/Php80/Php80.php#L101
+
+        if ('' === $needle || $needle === $haystack) {
+            return true;
+        }
+
+        if ('' === $haystack) {
+            return false;
+        }
+
+        $needleLength = \strlen($needle);
+
+        return $needleLength <= \strlen($haystack) && 0 === substr_compare($haystack, $needle, -$needleLength);
+    }
+
+    /**
+     * Polyfill for the `array_is_list` function introduced in PHP 8.1.
+     *
+     * @param array<mixed> $array
+     */
+    public static function array_is_list(array $array): bool
+    {
+        // Source: https://github.com/symfony/polyfill/blob/v1.29.0/src/Php81/Php81.php#L21
+
+        if ([] === $array || $array === array_values($array)) {
+            return true;
+        }
+
+        $nextKey = -1;
+
+        foreach ($array as $k => $v) {
+            if ($k !== ++$nextKey) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Returns the string representation of a value.
      *
      * @param mixed $value the value


### PR DESCRIPTION
### Describe the purpose of your pull request

The project uses a few functions (`str_starts_with`, `str_ends_with` `array_is_list`) that are not available in PHP 7. (Unfortunately, dev dependencies reference polyfills for these, so tests run successfully,  which masks the issue.)

This PR fixes the issue by adding the necessary polyfills.

### Related issues (only if applicable)

https://trello.com/c/QcUliWhL

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
